### PR TITLE
[FEAT] [ENDPOINT] `POST /api/expenses` to add expense

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.0'
+        php-version: '8.1.3'
     - uses: actions/checkout@v3
     - name: Copy .env.test.local
       run: php -r "file_exists('.env.test.local') || copy('.env.test', '.env.test.local');"

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": ">=8.0.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "doctrine/annotations": "^1.13",
         "doctrine/doctrine-bundle": "^2.6",
         "doctrine/doctrine-migrations-bundle": "^3.2",
         "doctrine/orm": "^2.11",
@@ -20,6 +21,7 @@
         "symfony/proxy-manager-bridge": "6.0.*",
         "symfony/runtime": "6.0.*",
         "symfony/twig-bundle": "6.0.*",
+        "symfony/validator": "6.0.*",
         "symfony/yaml": "6.0.*"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.0.2",
+        "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "doctrine/annotations": "^1.13",

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,10 @@
         "symfony/flex": "^2",
         "symfony/framework-bundle": "6.0.*",
         "symfony/maker-bundle": "^1.38",
+        "symfony/property-access": "6.0.*",
         "symfony/proxy-manager-bridge": "6.0.*",
         "symfony/runtime": "6.0.*",
+        "symfony/serializer": "6.0.*",
         "symfony/twig-bundle": "6.0.*",
         "symfony/validator": "6.0.*",
         "symfony/yaml": "6.0.*"
@@ -67,7 +69,7 @@
         ],
         "cs": "vendor/bin/php-cs-fixer fix -v",
         "lint": "@cs --dry-run",
-        "test": "symfony php bin/phpunit tests"
+        "test": "symfony php bin/phpunit tests --testdox"
     },
     "conflict": {
         "symfony/symfony": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9164ddca9ad46c044c1b11be4a01260",
+    "content-hash": "38659ed3637d6732e867f279704c3448",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -4032,6 +4032,85 @@
             "time": "2021-09-13T13:58:11+00:00"
         },
         {
+            "name": "symfony/property-access",
+            "version": "v6.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "384dbce5632f5a4f1117bbc59b050f8ff5f89cc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/384dbce5632f5a4f1117bbc59b050f8ff5f89cc4",
+                "reference": "384dbce5632f5a4f1117bbc59b050f8ff5f89cc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "symfony/property-info": "^5.4|^6.0"
+            },
+            "require-dev": {
+                "symfony/cache": "^5.4|^6.0"
+            },
+            "suggest": {
+                "psr/cache-implementation": "To cache access methods."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v6.0.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-31T17:18:25+00:00"
+        },
+        {
             "name": "symfony/property-info",
             "version": "v6.0.3",
             "source": {
@@ -4349,6 +4428,107 @@
                 }
             ],
             "time": "2022-02-21T17:15:17+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v6.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "384208d97ba09fdeeb49096bf3b3db4c2c48dcef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/384208d97ba09fdeeb49096bf3b3db4c2c48dcef",
+                "reference": "384208d97ba09fdeeb49096bf3b3db4c2c48dcef",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.12",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/property-access": "<5.4",
+                "symfony/property-info": "<5.4",
+                "symfony/uid": "<5.4",
+                "symfony/yaml": "<5.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.12",
+                "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/filesystem": "^5.4|^6.0",
+                "symfony/form": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/mime": "^5.4|^6.0",
+                "symfony/property-access": "^5.4|^6.0",
+                "symfony/property-info": "^5.4|^6.0",
+                "symfony/uid": "^5.4|^6.0",
+                "symfony/validator": "^5.4|^6.0",
+                "symfony/var-dumper": "^5.4|^6.0",
+                "symfony/var-exporter": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
+            },
+            "suggest": {
+                "psr/cache-implementation": "For using the metadata cache.",
+                "symfony/config": "For using the XML mapping loader.",
+                "symfony/mime": "For using a MIME type guesser within the DataUriNormalizer.",
+                "symfony/property-access": "For using the ObjectNormalizer.",
+                "symfony/property-info": "To deserialize relations.",
+                "symfony/var-exporter": "For using the metadata compiler.",
+                "symfony/yaml": "For using the default YAML mapping loader."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/serializer/tree/v6.0.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-24T18:04:39+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d185a97b3d93fbbb4d3876214ba3e91",
+    "content-hash": "d9164ddca9ad46c044c1b11be4a01260",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -4863,6 +4863,114 @@
                 }
             ],
             "time": "2022-01-02T09:55:41+00:00"
+        },
+        {
+            "name": "symfony/validator",
+            "version": "v6.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "62f66d9c3141429f4328e0a3981da5669cabaef0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/62f66d9c3141429f4328e0a3981da5669cabaef0",
+                "reference": "62f66d9c3141429f4328e0a3981da5669cabaef0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php81": "^1.22",
+                "symfony/translation-contracts": "^1.1|^2|^3"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.13",
+                "doctrine/lexer": "<1.1",
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/expression-language": "<5.4",
+                "symfony/http-kernel": "<5.4",
+                "symfony/intl": "<5.4",
+                "symfony/property-info": "<5.4",
+                "symfony/translation": "<5.4",
+                "symfony/yaml": "<5.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.13",
+                "egulias/email-validator": "^2.1.10|^3",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/intl": "^5.4|^6.0",
+                "symfony/mime": "^5.4|^6.0",
+                "symfony/property-access": "^5.4|^6.0",
+                "symfony/property-info": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
+            },
+            "suggest": {
+                "egulias/email-validator": "Strict (RFC compliant) email validation",
+                "psr/cache-implementation": "For using the mapping cache.",
+                "symfony/config": "",
+                "symfony/expression-language": "For using the Expression validator and the ExpressionLanguageSyntax constraints",
+                "symfony/http-foundation": "",
+                "symfony/intl": "",
+                "symfony/property-access": "For accessing properties within comparison constraints",
+                "symfony/property-info": "To automatically add NotNull and Type constraints",
+                "symfony/translation": "For translating validation errors.",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Validator\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to validate values",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/validator/tree/v6.0.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-31T17:18:25+00:00"
         },
         {
             "name": "symfony/var-dumper",

--- a/config/packages/validator.yaml
+++ b/config/packages/validator.yaml
@@ -1,0 +1,13 @@
+framework:
+    validation:
+        email_validation_mode: html5
+
+        # Enables validator auto-mapping support.
+        # For instance, basic validation constraints will be inferred from Doctrine's metadata.
+        #auto_mapping:
+        #    App\Entity\: []
+
+when@test:
+    framework:
+        validation:
+            not_compromised_password: false

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,6 +20,9 @@ services:
             - '../src/Entity/'
             - '../src/Enums/'
             - '../src/Kernel.php'
+    App\Listeners\ExceptionListener:
+        tags:
+            - { name: kernel.event_listener, event: kernel.exception, priority: 50 }
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Controller/ExpensesController.php
+++ b/src/Controller/ExpensesController.php
@@ -65,7 +65,9 @@ class ExpensesController extends AbstractController
     #[Route('/expenses', name: 'post_expenses', methods: ['POST'])]
     public function postExpense(CreateExpenseRequestDto $createExpenseDto): Response
     {
-        $createExpenseDto->validate();
+        if (!$createExpenseDto->valid()) {
+            return $createExpenseDto->validationResponse();
+        }
 
         if (is_numeric($createExpenseDto->getType())) {
             $expenseType = $this->typeRepository->find($createExpenseDto->getType());

--- a/src/Controller/ExpensesController.php
+++ b/src/Controller/ExpensesController.php
@@ -3,8 +3,10 @@
 namespace App\Controller;
 
 use App\Dto\CreateExpenseRequestDto;
+use App\Dto\ExpenseResponseDto;
 use App\Entity\Expense;
 use App\Exceptions\NotFoundException;
+use App\Mappers\ExpenseMapper;
 use App\Repository\ExpenseRepository;
 use App\Repository\ExpenseTypeRepository;
 use Doctrine\ORM\OptimisticLockException;
@@ -46,6 +48,8 @@ class ExpensesController extends AbstractController
     {
         $data = $this->repository->findAll();
 
+        $data = array_map(fn ($expense): ExpenseResponseDto => ExpenseMapper::entityToResponseDto($expense), $data);
+
         return new JsonResponse($data, 200, ['Content-Type' => 'application/json']);
     }
 
@@ -83,6 +87,6 @@ class ExpensesController extends AbstractController
             throw new NotFoundException('ExpenseType', $createExpenseDto->getType());
         }
 
-        return new JsonResponse([], 201, ['Content-Type' => 'application/json']);
+        return new JsonResponse(ExpenseMapper::entityToResponseDto($entity), 201, ['Content-Type' => 'application/json']);
     }
 }

--- a/src/Controller/ExpensesController.php
+++ b/src/Controller/ExpensesController.php
@@ -2,18 +2,28 @@
 
 namespace App\Controller;
 
+use App\Dto\CreateExpenseRequestDto;
 use App\Entity\Expense;
+use App\Exceptions\NotFoundException;
 use App\Repository\ExpenseRepository;
+use App\Repository\ExpenseTypeRepository;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use OpenApi\Annotations as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\CssSelector\Exception\InternalErrorException;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
+#[Route('/api', name: 'api_')]
 class ExpensesController extends AbstractController
 {
-    public function __construct(protected ExpenseRepository $repository)
-    {
+    public function __construct(
+        protected ExpenseRepository $repository,
+        protected ExpenseTypeRepository $typeRepository,
+    ) {
     }
 
     /**
@@ -28,10 +38,51 @@ class ExpensesController extends AbstractController
      *     )
      * )
      * @OA\Tag(name="expenses")
+     *
+     * @return Response
      */
-    #[Route('/api/expenses', name: 'app_expenses', methods: ['GET', 'HEAD'])]
+    #[Route('/expenses', name: 'get_expenses', methods: ['GET'])]
     public function getExpenses(): Response
     {
-        return $this->json($this->repository->findAll());
+        $data = $this->repository->findAll();
+
+        return new JsonResponse($data, 200, ['Content-Type' => 'application/json']);
+    }
+
+    /**
+     * Add an expense.
+     *
+     * @param CreateExpenseRequestDto $createExpenseDto
+     *
+     * @return Response
+     *
+     * @throws InternalErrorException
+     */
+    #[Route('/expenses', name: 'post_expenses', methods: ['POST'])]
+    public function postExpense(CreateExpenseRequestDto $createExpenseDto): Response
+    {
+        $createExpenseDto->validate();
+
+        if (is_numeric($createExpenseDto->getType())) {
+            $expenseType = $this->typeRepository->find($createExpenseDto->getType());
+        } else {
+            $expenseType = $this->typeRepository->findOneBy([
+                'name' => $createExpenseDto->getType(),
+            ]);
+        }
+
+        if ($expenseType) {
+            $entity = ExpenseRepository::create($createExpenseDto->getDescription(), $createExpenseDto->getValue(), $expenseType);
+
+            try {
+                $this->repository->add($entity);
+            } catch (OptimisticLockException|ORMException $e) {
+                throw new InternalErrorException('Unable to add your expense', 1, $e);
+            }
+        } else {
+            throw new NotFoundException('ExpenseType', $createExpenseDto->getType());
+        }
+
+        return new JsonResponse([], 201, ['Content-Type' => 'application/json']);
     }
 }

--- a/src/Dto/BaseRequestDto.php
+++ b/src/Dto/BaseRequestDto.php
@@ -32,7 +32,7 @@ abstract class BaseRequestDto
         return new JsonResponse($messages, 400);
     }
 
-    private function validate()
+    public function validate()
     {
         $errors = $this->validator->validate($this);
 

--- a/src/Dto/BaseRequestDto.php
+++ b/src/Dto/BaseRequestDto.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Dto;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+abstract class BaseRequestDto
+{
+    public function __construct(protected ValidatorInterface $validator)
+    {
+        $this->populate();
+
+        if ($this->autoValidateRequest()) {
+            $this->validate();
+        }
+    }
+
+    public function validate()
+    {
+        $errors = $this->validator->validate($this);
+
+        $messages = ['message' => 'validation_failed', 'errors' => []];
+
+        /* @var ConstraintViolation */
+        foreach ($errors as $message) {
+            $messages['errors'][] = [
+                'property' => $message->getPropertyPath(),
+                'value' => $message->getInvalidValue(),
+                'message' => $message->getMessage(),
+            ];
+        }
+
+        if (count($messages['errors']) > 0) {
+            $response = new JsonResponse($messages, 201);
+            $response->send();
+
+            exit;
+        }
+    }
+
+    public function getRequest(): Request
+    {
+        return Request::createFromGlobals();
+    }
+
+    protected function populate(): void
+    {
+        foreach ($this->getRequest()->toArray() as $property => $value) {
+            if (property_exists($this, $property)) {
+                $this->{$property} = $value;
+            }
+        }
+    }
+
+    protected function autoValidateRequest(): bool
+    {
+        return true;
+    }
+}

--- a/src/Dto/BaseRequestDto.php
+++ b/src/Dto/BaseRequestDto.php
@@ -64,7 +64,6 @@ abstract class BaseRequestDto
                 }
             }
         } catch (\Exception) {
-
         }
     }
 

--- a/src/Dto/CreateExpenseRequestDto.php
+++ b/src/Dto/CreateExpenseRequestDto.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Dto;
+
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+
+class CreateExpenseRequestDto extends BaseRequestDto
+{
+    #[Type('string')]
+    #[NotBlank()]
+    protected string $description;
+
+    #[Type('float')]
+    #[NotBlank()]
+    protected float $value;
+
+    #[Type('string')]
+    #[NotBlank()]
+    protected string $type;
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    protected function autoValidateRequest(): bool
+    {
+        return false;
+    }
+}

--- a/src/Dto/CreateExpenseRequestDto.php
+++ b/src/Dto/CreateExpenseRequestDto.php
@@ -2,22 +2,31 @@
 
 namespace App\Dto;
 
-use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CreateExpenseRequestDto extends BaseRequestDto
 {
-    #[Type('string')]
-    #[NotBlank()]
-    protected string $description;
+    #[Assert\Type('string')]
+    #[Assert\NotBlank()]
+    protected $description;
 
-    #[Type('float')]
-    #[NotBlank()]
-    protected float $value;
+    #[Assert\Type([
+        'float',
+        'integer',
+    ])]
+    #[Assert\NotBlank()]
+    #[Assert\Positive()]
+    protected $value;
 
-    #[Type('string')]
-    #[NotBlank()]
-    protected string $type;
+    #[Assert\Type(
+        type: [
+            'string',
+            'integer',
+        ],
+        message: 'The value {{ value }} is not a valid {{ type }} name or id',
+    )]
+    #[Assert\NotBlank()]
+    protected $type;
 
     public function getDescription(): string
     {
@@ -34,8 +43,27 @@ class CreateExpenseRequestDto extends BaseRequestDto
         return $this->type;
     }
 
-    protected function autoValidateRequest(): bool
+    /**
+     * @param $description
+     */
+    public function setDescription($description): void
     {
-        return false;
+        $this->description = $description;
+    }
+
+    /**
+     * @param $value
+     */
+    public function setValue($value): void
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param $type
+     */
+    public function setType($type): void
+    {
+        $this->type = $type;
     }
 }

--- a/src/Dto/ExpenseResponseDto.php
+++ b/src/Dto/ExpenseResponseDto.php
@@ -4,5 +4,11 @@ namespace App\Dto;
 
 class ExpenseResponseDto
 {
-
+    public function __construct(
+        public int $id,
+        public string $description,
+        public float $value,
+        public string $type)
+    {
+    }
 }

--- a/src/Dto/ExpenseResponseDto.php
+++ b/src/Dto/ExpenseResponseDto.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Dto;
+
+class ExpenseResponseDto
+{
+
+}

--- a/src/Entity/Expense.php
+++ b/src/Entity/Expense.php
@@ -33,7 +33,7 @@ class Expense
     public $value;
 
     /**
-     * @var string
+     * @var int
      * @OA\Property(description="The Type of the Expense.")
      */
     #[ORM\ManyToOne(targetEntity: ExpenseType::class, inversedBy: 'expenses')]

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Exceptions;
+
+class NotFoundException extends \RuntimeException
+{
+    public function __construct(string $entityName, int $id)
+    {
+        parent::__construct("$entityName #$id was not found");
+    }
+}

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 class NotFoundException extends \RuntimeException
 {
-    public function __construct(string $entityName, int $id)
+    public function __construct(string $entityName, int|string $id)
     {
         parent::__construct("$entityName #$id was not found");
     }

--- a/src/Listeners/ExceptionListener.php
+++ b/src/Listeners/ExceptionListener.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Exceptions\NotFoundException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class ExceptionListener implements LoggerAwareInterface
+{
+    private LoggerInterface $logger;
+
+    public function __construct()
+    {
+    }
+
+    public function onKernelException(ExceptionEvent $event)
+    {
+        $exception = $event->getThrowable();
+
+        $response = new JsonResponse();
+
+        $this->logger->error($exception->getMessage(), $exception->getTrace());
+
+        if ($exception instanceof NotFoundException) {
+            $response->setStatusCode(Response::HTTP_NOT_FOUND);
+        } elseif ($exception instanceof HttpExceptionInterface) {
+            $response->setStatusCode($exception->getStatusCode());
+            $response->headers->replace($exception->getHeaders());
+        } else {
+            $response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        $data = [
+            'message' => $exception->getMessage(),
+            'statusCode' => $response->getStatusCode(),
+        ];
+
+        $response->setData($data);
+
+        $event->setResponse($response);
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+}

--- a/src/Mappers/ExpenseMapper.php
+++ b/src/Mappers/ExpenseMapper.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Mappers;
+
+use App\Dto\ExpenseResponseDto;
+use App\Entity\Expense;
+
+class ExpenseMapper
+{
+    public static function entityToResponseDto(Expense $expense): ExpenseResponseDto
+    {
+        return new ExpenseResponseDto(
+            $expense->getId(),
+            $expense->getDescription(),
+            $expense->getValue(),
+            $expense->getExpenseType()->getName(),
+        );
+    }
+}

--- a/src/Repository/ExpenseRepository.php
+++ b/src/Repository/ExpenseRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Expense;
+use App\Entity\ExpenseType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
@@ -45,32 +46,13 @@ class ExpenseRepository extends ServiceEntityRepository
         }
     }
 
-    // /**
-    //  * @return Expense[] Returns an array of Expense objects
-    //  */
-    /*
-    public function findByExampleField($value)
+    public static function create(string $description, string $value, ExpenseType $type): Expense
     {
-        return $this->createQueryBuilder('e')
-            ->andWhere('e.exampleField = :val')
-            ->setParameter('val', $value)
-            ->orderBy('e.id', 'ASC')
-            ->setMaxResults(10)
-            ->getQuery()
-            ->getResult()
-        ;
-    }
-    */
+        $entity = new Expense();
+        $entity->setDescription($description);
+        $entity->setValue($value);
+        $entity->setExpenseType($type);
 
-    /*
-    public function findOneBySomeField($value): ?Expense
-    {
-        return $this->createQueryBuilder('e')
-            ->andWhere('e.exampleField = :val')
-            ->setParameter('val', $value)
-            ->getQuery()
-            ->getOneOrNullResult()
-        ;
+        return $entity;
     }
-    */
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -396,6 +396,9 @@
     "symfony/process": {
         "version": "v6.0.5"
     },
+    "symfony/property-access": {
+        "version": "v6.0.7"
+    },
     "symfony/property-info": {
         "version": "v6.0.3"
     },
@@ -417,6 +420,9 @@
     },
     "symfony/runtime": {
         "version": "v6.0.5"
+    },
+    "symfony/serializer": {
+        "version": "v6.0.7"
     },
     "symfony/service-contracts": {
         "version": "v3.0.0"

--- a/symfony.lock
+++ b/symfony.lock
@@ -446,6 +446,18 @@
             "templates/base.html.twig"
         ]
     },
+    "symfony/validator": {
+        "version": "6.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "5.3",
+            "ref": "c32cfd98f714894c4f128bb99aa2530c1227603c"
+        },
+        "files": [
+            "config/packages/validator.yaml"
+        ]
+    },
     "symfony/var-dumper": {
         "version": "v6.0.6"
     },

--- a/tests/DatabasePrimer.php
+++ b/tests/DatabasePrimer.php
@@ -3,7 +3,6 @@
 namespace App\Tests;
 
 use App\DataFixtures\AppFixtures;
-use App\DataFixtures\TestFixtures;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Component\HttpKernel\KernelInterface;
 

--- a/tests/ExpenseTest.php
+++ b/tests/ExpenseTest.php
@@ -34,6 +34,7 @@ class ExpenseTest extends KernelTestCase
     /** @test */
     public function shouldHaveFiveExpenseTypesFixturesFromStart()
     {
+        // Arrange
         $expenseTypeRepository = $this->entityManager->getRepository(ExpenseType::class);
 
         $expenseTypes = [
@@ -45,18 +46,25 @@ class ExpenseTest extends KernelTestCase
         ];
 
         foreach ($expenseTypes as $expenseType) {
+            // Act
             /** @var ExpenseType $expenseTypeRecord */
             $expenseTypeRecord = $expenseTypeRepository->findOneBy(['name' => $expenseType]);
+
+            // Assert
             $this->assertNotEmpty($expenseTypeRecord);
         }
 
+        // Act
         $allExpenseTypeCount = $expenseTypeRepository->count([]);
+
+        // Assert
         $this->assertEquals(count($expenseTypes), $allExpenseTypeCount);
     }
 
     /** @test */
     public function anExpenseCanBeCreatedInTheDatabase()
     {
+        // Arrange
         $expenseTypeRepository = $this->entityManager->getRepository(ExpenseType::class);
 
         /** @var ExpenseType $expenseTypeRecord */
@@ -70,6 +78,7 @@ class ExpenseTest extends KernelTestCase
         $expense->setValue($expenseValue);
         $expense->setExpenseType($expenseTypeRecord);
 
+        // Act
         $this->entityManager->persist($expense);
         $this->entityManager->flush();
 
@@ -81,6 +90,7 @@ class ExpenseTest extends KernelTestCase
             'value' => $expenseValue,
         ]);
 
+        // Assert
         $this->assertEquals($expenseDescription, $expenseRecord->getDescription());
         $this->assertEquals($expenseValue, $expenseRecord->getValue());
         $this->assertEquals(ExpenseTypeEnum::ENTERTAINMENT, $expenseRecord->getExpenseType()->getName());

--- a/tests/ExpenseTest.php
+++ b/tests/ExpenseTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace App\Tests\unit\Entity;
+namespace App\Tests;
 
 use App\Entity\Expense;
 use App\Entity\ExpenseType;
 use App\Enums\ExpenseTypeEnum;
-use App\Tests\DatabasePrimer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 

--- a/tests/ExpenseTest.php
+++ b/tests/ExpenseTest.php
@@ -57,7 +57,7 @@ class ExpenseTest extends KernelTestCase
         $allExpenseTypeCount = $expenseTypeRepository->count([]);
 
         // Assert
-        $this->assertEquals(count($expenseTypes), $allExpenseTypeCount);
+        $this->assertSame(count($expenseTypes), $allExpenseTypeCount);
     }
 
     /** @test */
@@ -90,8 +90,8 @@ class ExpenseTest extends KernelTestCase
         ]);
 
         // Assert
-        $this->assertEquals($expenseDescription, $expenseRecord->getDescription());
-        $this->assertEquals($expenseValue, $expenseRecord->getValue());
-        $this->assertEquals(ExpenseTypeEnum::ENTERTAINMENT, $expenseRecord->getExpenseType()->getName());
+        $this->assertSame($expenseDescription, $expenseRecord->getDescription());
+        $this->assertSame($expenseValue, $expenseRecord->getValue());
+        $this->assertSame(ExpenseTypeEnum::ENTERTAINMENT, $expenseRecord->getExpenseType()->getName());
     }
 }

--- a/tests/Integration/Controller/ExpensesControllerTest.php
+++ b/tests/Integration/Controller/ExpensesControllerTest.php
@@ -67,7 +67,7 @@ class ExpensesControllerTest extends WebTestCase
         $response = $controller->getExpenses();
 
         // Assert
-        $this->assertEquals('[]', $response->getContent());
+        $this->assertSame('[]', $response->getContent());
     }
 
     /** @test */
@@ -89,10 +89,10 @@ class ExpensesControllerTest extends WebTestCase
         $actualExpense = $expensesResponse[0];
 
         // Assert
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertNotEmpty($expensesResponse);
-        $this->assertEquals($expectedExpense->description, $actualExpense->description);
-        $this->assertEquals($expectedExpense->value, $actualExpense->value);
+        $this->assertSame($expectedExpense->description, $actualExpense->description);
+        $this->assertSame($expectedExpense->value, $actualExpense->value);
     }
 
     /** @test
@@ -117,7 +117,7 @@ class ExpensesControllerTest extends WebTestCase
         $response = $this->controller->postExpense($createExpenseDto);
 
         // Assert
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function postExpenseBadBodyProvider(): array
@@ -217,15 +217,15 @@ class ExpensesControllerTest extends WebTestCase
         $response = $this->controller->postExpense($createExpenseDto);
 
         // Assert
-        $this->assertEquals(201, $response->getStatusCode(), 'Should return 201 status code');
+        $this->assertSame(201, $response->getStatusCode(), 'Should return 201 status code');
         $expenseRepository = $this->entityManager->getRepository(Expense::class);
         /** @var Expense $actualExpense */
         $actualExpense = $expenseRepository->findOneBy([
             'description' => $expectedExpense['description'],
         ]);
-        $this->assertEquals($expectedExpense['description'], $actualExpense->getDescription(), 'Saved Expense description match payload description');
+        $this->assertSame($expectedExpense['description'], $actualExpense->getDescription(), 'Saved Expense description match payload description');
         $this->assertEquals($expectedExpense['value'], $actualExpense->getValue(), 'Saved Expense value match payload value');
-        $this->assertEquals($expectedExpense['type'], $actualExpense->getExpenseType()->getName(), 'Saved Expense type match payload type');
+        $this->assertSame($expectedExpense['type'], $actualExpense->getExpenseType()->getName(), 'Saved Expense type match payload type');
     }
 
     /** @test */
@@ -254,16 +254,16 @@ class ExpensesControllerTest extends WebTestCase
         $response = $this->controller->postExpense($createExpenseDto);
 
         // Assert
-        $this->assertEquals(201, $response->getStatusCode(), 'Should return 201 status code');
+        $this->assertSame(201, $response->getStatusCode(), 'Should return 201 status code');
 
         $expenseRepository = $this->entityManager->getRepository(Expense::class);
         /** @var Expense $actualExpense */
         $actualExpense = $expenseRepository->findOneBy([
             'description' => $expectedExpense['description'],
         ]);
-        $this->assertEquals($expectedExpense['description'], $actualExpense->getDescription(), 'Saved Expense description match payload description');
+        $this->assertSame($expectedExpense['description'], $actualExpense->getDescription(), 'Saved Expense description match payload description');
         $this->assertEquals($expectedExpense['value'], $actualExpense->getValue(), 'Saved Expense value match payload value');
-        $this->assertEquals($expenseType->getName(), $actualExpense->getExpenseType()->getName(), 'Saved Expense type match payload type');
-        $this->assertEquals($expenseType->getId(), $actualExpense->getExpenseType()->getId(), 'Saved Expense type Id match payload type Id');
+        $this->assertSame($expenseType->getName(), $actualExpense->getExpenseType()->getName(), 'Saved Expense type match payload type');
+        $this->assertSame($expenseType->getId(), $actualExpense->getExpenseType()->getId(), 'Saved Expense type Id match payload type Id');
     }
 }

--- a/tests/Integration/Controller/ExpensesControllerTest.php
+++ b/tests/Integration/Controller/ExpensesControllerTest.php
@@ -58,11 +58,15 @@ class ExpensesControllerTest extends WebTestCase
     /** @test */
     public function getExpensesShouldReturnEmptyData(): void
     {
+        // Arrange
         $container = static::getContainer();
         /** @var ExpensesController $controller */
         $controller = $container->get(ExpensesController::class);
+
+        // Act
         $response = $controller->getExpenses();
 
+        // Assert
         $this->assertEquals('[]', $response->getContent());
     }
 
@@ -99,6 +103,7 @@ class ExpensesControllerTest extends WebTestCase
     public function postExpenseShouldReturnBadRequest(
         object $jsonBody,
     ): void {
+        // Arrange
         /** @var ValidatorInterface $validator */
         $validator = $this->container->get(ValidatorInterface::class);
         $data = json_encode($jsonBody);
@@ -107,7 +112,11 @@ class ExpensesControllerTest extends WebTestCase
                 CreateExpenseRequestDto::class => ['validator' => $validator],
             ],
         ]);
+
+        // Act
         $response = $this->controller->postExpense($createExpenseDto);
+
+        // Assert
         $this->assertEquals(400, $response->getStatusCode());
     }
 
@@ -168,6 +177,7 @@ class ExpensesControllerTest extends WebTestCase
     /** @test */
     public function postExpenseShouldThrowNotFoundExceptionOnNonExistingType(): void
     {
+        // Arrange
         /** @var ValidatorInterface $validator */
         $validator = $this->container->get(ValidatorInterface::class);
         $data = json_encode((object) [
@@ -180,6 +190,8 @@ class ExpensesControllerTest extends WebTestCase
                 CreateExpenseRequestDto::class => ['validator' => $validator],
             ],
         ]);
+
+        // Act | Assert
         $this->expectException(NotFoundException::class);
         $this->controller->postExpense($createExpenseDto);
     }
@@ -187,6 +199,7 @@ class ExpensesControllerTest extends WebTestCase
     /** @test */
     public function postExpenseShouldAddExpenseOnValidPayload(): void
     {
+        // Arrange
         /** @var ValidatorInterface $validator */
         $validator = $this->container->get(ValidatorInterface::class);
         $expectedExpense = [
@@ -199,8 +212,11 @@ class ExpensesControllerTest extends WebTestCase
                 CreateExpenseRequestDto::class => ['validator' => $validator],
             ],
         ]);
+
+        // Act
         $response = $this->controller->postExpense($createExpenseDto);
 
+        // Assert
         $this->assertEquals(201, $response->getStatusCode(), 'Should return 201 status code');
         $expenseRepository = $this->entityManager->getRepository(Expense::class);
         /** @var Expense $actualExpense */

--- a/tests/Integration/Controller/ExpensesControllerTest.php
+++ b/tests/Integration/Controller/ExpensesControllerTest.php
@@ -4,14 +4,30 @@ namespace App\Tests\Integration\Controller;
 
 use App\Controller\ExpensesController;
 use App\DataFixtures\TestFixtures;
+use App\Dto\CreateExpenseRequestDto;
+use App\Entity\Expense;
+use App\Entity\ExpenseType;
+use App\Exceptions\NotFoundException;
 use App\Tests\DatabasePrimer;
 use Doctrine\ORM\EntityManagerInterface;
+use Exception;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ExpensesControllerTest extends WebTestCase
 {
     /** @var EntityManagerInterface */
     private $entityManager;
+    private $container;
+
+    /** @var ExpensesController */
+    private $controller;
+
+    /** @var Serializer */
+    private $serializer;
 
     protected function setUp(): void
     {
@@ -19,7 +35,16 @@ class ExpensesControllerTest extends WebTestCase
 
         DatabasePrimer::prime(self::$kernel);
 
+        $this->container = static::getContainer();
+
+        $this->controller = $this->container->get(ExpensesController::class);
+
         $this->entityManager = self::$kernel->getContainer()->get('doctrine')->getManager();
+
+        $encoders = [new JsonEncoder()];
+        $normalizers = [new ObjectNormalizer()];
+
+        $this->serializer = new Serializer($normalizers, $encoders);
     }
 
     protected function tearDown(): void
@@ -54,12 +79,8 @@ class ExpensesControllerTest extends WebTestCase
         $testFixtures = new TestFixtures();
         $testFixtures->load($this->entityManager, $expectedExpense->description);
 
-        $container = static::getContainer();
-        /** @var ExpensesController $controller */
-        $controller = $container->get(ExpensesController::class);
-
         // Act
-        $response = $controller->getExpenses();
+        $response = $this->controller->getExpenses();
         $expensesResponse = json_decode($response->getContent());
         $actualExpense = $expensesResponse[0];
 
@@ -68,5 +89,165 @@ class ExpensesControllerTest extends WebTestCase
         $this->assertNotEmpty($expensesResponse);
         $this->assertEquals($expectedExpense->description, $actualExpense->description);
         $this->assertEquals($expectedExpense->value, $actualExpense->value);
+    }
+
+    /** @test
+     * @dataProvider postExpenseBadBodyProvider
+     *
+     * @throws Exception
+     */
+    public function postExpenseShouldReturnBadRequest(
+        object $jsonBody,
+    ): void {
+        /** @var ValidatorInterface $validator */
+        $validator = $this->container->get(ValidatorInterface::class);
+        $data = json_encode($jsonBody);
+        $createExpenseDto = $this->serializer->deserialize($data, CreateExpenseRequestDto::class, 'json', [
+            'default_constructor_arguments' => [
+                CreateExpenseRequestDto::class => ['validator' => $validator],
+            ],
+        ]);
+        $response = $this->controller->postExpense($createExpenseDto);
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function postExpenseBadBodyProvider(): array
+    {
+        $allData = [
+            'description' => 'Test Description',
+            'value' => 10,
+            'type' => 'Entertainment',
+        ];
+        $allParamsMissing = [];
+        $missingDescription = [
+            ...$allData,
+        ];
+        unset($missingDescription['description']);
+        $emptyDescription = [
+            ...$allData,
+            'description' => '',
+        ];
+        $missingValue = [
+            ...$allData,
+        ];
+        unset($missingValue['value']);
+        $stringValue = [
+            ...$allData,
+            'value' => 'not-valid',
+        ];
+        $zeroValue = [
+            ...$allData,
+            'value' => 0,
+        ];
+        $negativeValue = [
+            ...$allData,
+            'value' => -1,
+        ];
+        $missingType = [
+            ...$allData,
+        ];
+        unset($missingType['type']);
+        $emptyType = [
+            ...$allData,
+            'type' => '',
+        ];
+
+        return [
+            'Empty Body' => [(object) $allParamsMissing],
+            'Missing Description' => [(object) $missingDescription],
+            'Empty Description' => [(object) $emptyDescription],
+            'Missing Value' => [(object) $missingValue],
+            'Value as String' => [(object) $stringValue],
+            'Value as zero' => [(object) $zeroValue],
+            'Negative Value' => [(object) $negativeValue],
+            'Missing Type' => [(object) $missingType],
+            'an Empty Type' => [(object) $emptyType],
+        ];
+    }
+
+    /** @test */
+    public function postExpenseShouldThrowNotFoundExceptionOnNonExistingType(): void
+    {
+        /** @var ValidatorInterface $validator */
+        $validator = $this->container->get(ValidatorInterface::class);
+        $data = json_encode((object) [
+            'description' => 'Test Description',
+            'value' => 10,
+            'type' => 'Not Found',
+        ]);
+        $createExpenseDto = $this->serializer->deserialize($data, CreateExpenseRequestDto::class, 'json', [
+            'default_constructor_arguments' => [
+                CreateExpenseRequestDto::class => ['validator' => $validator],
+            ],
+        ]);
+        $this->expectException(NotFoundException::class);
+        $this->controller->postExpense($createExpenseDto);
+    }
+
+    /** @test */
+    public function postExpenseShouldAddExpenseOnValidPayload(): void
+    {
+        /** @var ValidatorInterface $validator */
+        $validator = $this->container->get(ValidatorInterface::class);
+        $expectedExpense = [
+            'description' => 'Post expense should add expense on valid payload',
+            'value' => 10,
+            'type' => 'Entertainment',
+        ];
+        $createExpenseDto = $this->serializer->deserialize(json_encode((object) $expectedExpense), CreateExpenseRequestDto::class, 'json', [
+            'default_constructor_arguments' => [
+                CreateExpenseRequestDto::class => ['validator' => $validator],
+            ],
+        ]);
+        $response = $this->controller->postExpense($createExpenseDto);
+
+        $this->assertEquals(201, $response->getStatusCode(), 'Should return 201 status code');
+        $expenseRepository = $this->entityManager->getRepository(Expense::class);
+        /** @var Expense $actualExpense */
+        $actualExpense = $expenseRepository->findOneBy([
+            'description' => $expectedExpense['description'],
+        ]);
+        $this->assertEquals($expectedExpense['description'], $actualExpense->getDescription(), 'Saved Expense description match payload description');
+        $this->assertEquals($expectedExpense['value'], $actualExpense->getValue(), 'Saved Expense value match payload value');
+        $this->assertEquals($expectedExpense['type'], $actualExpense->getExpenseType()->getName(), 'Saved Expense type match payload type');
+    }
+
+    /** @test */
+    public function postExpenseShouldKnowPayloadTypeIfIdPosted(): void
+    {
+        // Arrange
+        /** @var ValidatorInterface $validator */
+        $validator = $this->container->get(ValidatorInterface::class);
+        $expenseRepository = $this->entityManager->getRepository(ExpenseType::class);
+        /** @var ExpenseType $expenseType */
+        $expenseType = $expenseRepository->findOneBy([
+            'name' => 'Entertainment',
+        ]);
+        $expectedExpense = [
+            'description' => 'Post expense should add expense on valid payload',
+            'value' => 10,
+            'type' => $expenseType->getId(),
+        ];
+        $createExpenseDto = $this->serializer->deserialize(json_encode((object) $expectedExpense), CreateExpenseRequestDto::class, 'json', [
+            'default_constructor_arguments' => [
+                CreateExpenseRequestDto::class => ['validator' => $validator],
+            ],
+        ]);
+
+        // Act
+        $response = $this->controller->postExpense($createExpenseDto);
+
+        // Assert
+        $this->assertEquals(201, $response->getStatusCode(), 'Should return 201 status code');
+
+        $expenseRepository = $this->entityManager->getRepository(Expense::class);
+        /** @var Expense $actualExpense */
+        $actualExpense = $expenseRepository->findOneBy([
+            'description' => $expectedExpense['description'],
+        ]);
+        $this->assertEquals($expectedExpense['description'], $actualExpense->getDescription(), 'Saved Expense description match payload description');
+        $this->assertEquals($expectedExpense['value'], $actualExpense->getValue(), 'Saved Expense value match payload value');
+        $this->assertEquals($expenseType->getName(), $actualExpense->getExpenseType()->getName(), 'Saved Expense type match payload type');
+        $this->assertEquals($expenseType->getId(), $actualExpense->getExpenseType()->getId(), 'Saved Expense type Id match payload type Id');
     }
 }

--- a/tests/Integration/Listeners/ExceptionListenerTest.php
+++ b/tests/Integration/Listeners/ExceptionListenerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Unit\Listeners;
+namespace App\Tests\Integration\Listeners;
 
 use App\Exceptions\NotFoundException;
 use App\Listeners\ExceptionListener;
@@ -43,7 +43,7 @@ class ExceptionListenerTest extends KernelTestCase
 
         // Assert
         $actual = $exceptionEventMock->getResponse()->getStatusCode();
-        $this->assertEquals(404, $actual);
+        $this->assertSame(404, $actual);
     }
 
     /** @test */
@@ -57,7 +57,7 @@ class ExceptionListenerTest extends KernelTestCase
 
         // Assert
         $actual = $exceptionEventMock->getResponse()->getStatusCode();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /** @test */
@@ -71,6 +71,6 @@ class ExceptionListenerTest extends KernelTestCase
 
         // Assert
         $actual = $exceptionEventMock->getResponse()->getStatusCode();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/Unit/Controller/ExpensesControllerTest.php
+++ b/tests/Unit/Controller/ExpensesControllerTest.php
@@ -58,6 +58,6 @@ class ExpensesControllerTest extends TestCase
         $content = $this->controller->getExpenses()->getContent();
 
         // Assert
-        $this->assertEquals(json_encode([$expected]), $content);
+        $this->assertSame(json_encode([$expected]), $content);
     }
 }

--- a/tests/Unit/Controller/ExpensesControllerTest.php
+++ b/tests/Unit/Controller/ExpensesControllerTest.php
@@ -43,6 +43,7 @@ class ExpensesControllerTest extends TestCase
     /** @test */
     public function getExpensesShouldReturnExpectedResponse(): void
     {
+        // Arrange
         $expected = (object) [
             'id' => $this->expenseMock->getId(),
             'description' => $this->expenseMock->getDescription(),
@@ -53,6 +54,10 @@ class ExpensesControllerTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
         $this->controller->setContainer($container);
 
-        $this->assertEquals(json_encode([$expected]), $this->controller->getExpenses()->getContent());
+        // Act
+        $content = $this->controller->getExpenses()->getContent();
+
+        // Assert
+        $this->assertEquals(json_encode([$expected]), $content);
     }
 }

--- a/tests/Unit/Controller/ExpensesControllerTest.php
+++ b/tests/Unit/Controller/ExpensesControllerTest.php
@@ -7,33 +7,45 @@ use App\Entity\Expense;
 use App\Entity\ExpenseType;
 use App\Enums\ExpenseTypeEnum;
 use App\Repository\ExpenseRepository;
+use App\Repository\ExpenseTypeRepository;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 class ExpensesControllerTest extends TestCase
 {
-    /** @test */
-    public function getExpensesShouldReturnExpectedResponse(): void
+    protected ExpensesController $controller;
+    protected Expense $expenseMock;
+
+    public function setUp(): void
     {
-        $expenseMock = new Expense();
-        $expenseMock->setDescription('Expense Mock');
-        $expenseMock->setValue(10);
+        parent::setUp();
+        $this->expenseMock = new Expense();
+        $this->expenseMock->setDescription('Expense Mock');
+        $this->expenseMock->setValue(10);
 
         $expenseTypeMock = new ExpenseType();
         $expenseTypeMock->setName(ExpenseTypeEnum::ENTERTAINMENT);
-        $expenseMock->setExpenseType($expenseTypeMock);
+        $this->expenseMock->setExpenseType($expenseTypeMock);
 
         /** @var ExpenseRepository $expenseRepositoryMock */
         $expenseRepositoryMock = $this->createMock(ExpenseRepository::class);
         $expenseRepositoryMock
             ->method('findAll')
-            ->willReturn([$expenseMock]);
+            ->willReturn([$this->expenseMock]);
 
-        $controller = new ExpensesController($expenseRepositoryMock);
+        /** @var ExpenseTypeRepository $expenseTypeRepositoryMock */
+        $expenseTypeRepositoryMock = $this->createMock(ExpenseTypeRepository::class);
+
+        $this->controller = new ExpensesController($expenseRepositoryMock, $expenseTypeRepositoryMock);
+    }
+
+    /** @test */
+    public function getExpensesShouldReturnExpectedResponse(): void
+    {
 
         $container = $this->createMock(ContainerInterface::class);
-        $controller->setContainer($container);
+        $this->controller->setContainer($container);
 
-        $this->assertEquals(json_encode([$expenseMock]), $controller->getExpenses()->getContent());
+        $this->assertEquals(json_encode([$this->expenseMock]), $this->controller->getExpenses()->getContent());
     }
 }

--- a/tests/Unit/Controller/ExpensesControllerTest.php
+++ b/tests/Unit/Controller/ExpensesControllerTest.php
@@ -20,6 +20,7 @@ class ExpensesControllerTest extends TestCase
     {
         parent::setUp();
         $this->expenseMock = new Expense();
+        $this->expenseMock->id = 1;
         $this->expenseMock->setDescription('Expense Mock');
         $this->expenseMock->setValue(10);
 
@@ -42,10 +43,16 @@ class ExpensesControllerTest extends TestCase
     /** @test */
     public function getExpensesShouldReturnExpectedResponse(): void
     {
+        $expected = (object) [
+            'id' => $this->expenseMock->getId(),
+            'description' => $this->expenseMock->getDescription(),
+            'value' => $this->expenseMock->getValue(),
+            'type' => $this->expenseMock->getExpenseType()->getName(),
+        ];
 
         $container = $this->createMock(ContainerInterface::class);
         $this->controller->setContainer($container);
 
-        $this->assertEquals(json_encode([$this->expenseMock]), $this->controller->getExpenses()->getContent());
+        $this->assertEquals(json_encode([$expected]), $this->controller->getExpenses()->getContent());
     }
 }

--- a/tests/Unit/Dto/BaseRequestDtoTest.php
+++ b/tests/Unit/Dto/BaseRequestDtoTest.php
@@ -39,7 +39,7 @@ class BaseRequestDtoTest extends TestCase
         $isValid = $this->testBaseRequest->valid();
 
         // Assert
-        $this->assertEquals(false, $isValid);
+        $this->assertSame(false, $isValid);
     }
 
     /** @test */
@@ -51,7 +51,7 @@ class BaseRequestDtoTest extends TestCase
         // Assert
         $this->assertArrayHasKey('errors', $errors);
         $this->assertCount(1, $errors['errors']);
-        $this->assertEquals('validation_failed', $errors['message']);
+        $this->assertSame('validation_failed', $errors['message']);
         $this->assertArrayHasKey('message', $errors);
     }
 
@@ -62,6 +62,6 @@ class BaseRequestDtoTest extends TestCase
         $response = $this->testBaseRequest->validationResponse();
 
         // Assert
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame(400, $response->getStatusCode());
     }
 }

--- a/tests/Unit/Dto/BaseRequestDtoTest.php
+++ b/tests/Unit/Dto/BaseRequestDtoTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Tests\Unit\Dto;
+
+use App\Dto\BaseRequestDto;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class TestBaseRequest extends BaseRequestDto
+{
+}
+
+class BaseRequestDtoTest extends TestCase
+{
+    protected $testBaseRequest;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Arrange
+        $validatorMock = $this->createMock(ValidatorInterface::class);
+        $constraintViolationList = new ConstraintViolationList();
+        $constraintViolationList->add(new ConstraintViolation('Error', '', [], '', '', ''));
+
+        $validatorMock
+            ->method('validate')
+            ->willReturn($constraintViolationList);
+
+        $this->testBaseRequest = new TestBaseRequest($validatorMock);
+    }
+
+    /** @test */
+    public function validShouldReturnFalseOnError()
+    {
+        // Act
+        $isValid = $this->testBaseRequest->valid();
+
+        // Assert
+        $this->assertEquals(false, $isValid);
+    }
+
+    /** @test */
+    public function validateShouldReturnErrorsArrayOnFailure()
+    {
+        // Act
+        $errors = $this->testBaseRequest->validate();
+
+        // Assert
+        $this->assertArrayHasKey('errors', $errors);
+        $this->assertCount(1, $errors['errors']);
+        $this->assertEquals('validation_failed', $errors['message']);
+        $this->assertArrayHasKey('message', $errors);
+    }
+
+    /** @test */
+    public function validateResponseShouldReturnJsonResponseContainingTheError()
+    {
+        // Act
+        $response = $this->testBaseRequest->validationResponse();
+
+        // Assert
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+}

--- a/tests/Unit/Listeners/ExceptionListenerTest.php
+++ b/tests/Unit/Listeners/ExceptionListenerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Tests\Unit\Listeners;
+
+use App\Exceptions\NotFoundException;
+use App\Listeners\ExceptionListener;
+use Doctrine\ORM\ORMException;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ExceptionListenerTest extends KernelTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+    }
+
+    private function getEvent(\Throwable $e): ExceptionEvent
+    {
+        // Arrange
+        $request = $this->createMock(Request::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $exceptionEventMock = new ExceptionEvent(self::$kernel, $request, 1, $e);
+
+        $exceptionListener = new ExceptionListener();
+        $exceptionListener->setLogger($logger);
+        $exceptionListener->onKernelException($exceptionEventMock);
+
+        return $exceptionEventMock;
+    }
+
+    /** @test */
+    public function shouldReturn404StatusCodeOnNotFoundException()
+    {
+        // Arrange | Act
+        $exceptionEventMock = $this->getEvent(new NotFoundException('Expense', 1));
+
+        // Assert
+        $actual = $exceptionEventMock->getResponse()->getStatusCode();
+        $this->assertEquals(404, $actual);
+    }
+
+    /** @test */
+    public function shouldReturnExpectedStatusCodeOnHttpException()
+    {
+        // Arrange
+        $expected = 400;
+
+        // Act
+        $exceptionEventMock = $this->getEvent(new HttpException($expected, 'Error Message'));
+
+        // Assert
+        $actual = $exceptionEventMock->getResponse()->getStatusCode();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /** @test */
+    public function shouldReturn500StatusCodeOnUnknownException()
+    {
+        // Arrange
+        $expected = 500;
+
+        // Act
+        $exceptionEventMock = $this->getEvent(new ORMException('Error Message'));
+
+        // Assert
+        $actual = $exceptionEventMock->getResponse()->getStatusCode();
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/Unit/Mappers/ExpenseMapperTest.php
+++ b/tests/Unit/Mappers/ExpenseMapperTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Tests\Unit\Mappers;
+
+use App\Entity\Expense;
+use App\Entity\ExpenseType;
+use App\Mappers\ExpenseMapper;
+use PHPUnit\Framework\TestCase;
+
+class ExpenseMapperTest extends TestCase
+{
+    /** @test */
+    public function shouldReturnExpectedObject()
+    {
+        // Arrange
+        $expense = new Expense();
+        $expense->id = 1;
+        $expense->setValue(10);
+        $expense->setDescription('Description');
+        $expenseType = new ExpenseType();
+        $expenseType->id = 1;
+        $expenseType->setName('Entertainment');
+        $expense->setExpenseType($expenseType);
+
+        // Act
+        $mappedObject = ExpenseMapper::entityToResponseDto($expense);
+
+        // Assert
+        $this->assertSame($expense->getId(), $mappedObject->id);
+        $this->assertSame($expense->getDescription(), $mappedObject->description);
+        $this->assertSame($expense->getValue(), $mappedObject->value);
+        $this->assertSame($expense->getExpenseType()->getName(), $mappedObject->type);
+    }
+}


### PR DESCRIPTION
## Changes

- Added `Post /api/expenses`
- Exceptions
- Exception Listener
- Form Validator
- Refactor unit tests.
- Added Mapper
- Added Integration Test

## To Test

- run `composer test` and expect 100% success rate
- hist `POST /api/expenses` manually then call the get and assert your expense added

```curl
curl --location --request POST 'http://localhost:8000/api/expenses' \
--header 'Content-Type: application/json' \
--data-raw '{
    "description": "Test Description",
    "type": "Entertainment",
    "value": 12
}'
```