### PR TITLE
[FEAT] [ENDPOINT] `GET /expenses/{id}` entry point and swagger.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ start-dev-db-server:
 init: start-dev-db-server
 	composer install && \
 	symfony console doctrine:migrations:migrate -q && \
-	symfony console doctrine:fixtures:load -q
+	symfony console doctrine:fixtures:load -q --purge-with-truncate --group=app-initial-data
 
 run:
 	symfony server:start

--- a/src/Controller/ExpensesController.php
+++ b/src/Controller/ExpensesController.php
@@ -127,4 +127,41 @@ class ExpensesController extends AbstractController
 
         return new JsonResponse(ExpenseMapper::entityToResponseDto($entity), 201, ['Content-Type' => 'application/json']);
     }
+
+    /**
+     * Get Expense by id.
+     *
+     * @OA\Response(
+     *     response=200,
+     *     description="Return matched expense by id",
+     *     @OA\JsonContent(ref=@Model(type=ExpenseResponseDto::class))
+     * )
+     *
+     * @OA\Response(
+     *     response=400,
+     *     description="Bad Request"
+     * )
+     *
+     * @OA\Response(
+     *     response=404,
+     *     description="Requested expense id not found"
+     * )
+     *
+     * @OA\Parameter(
+     *     name="id",
+     *     in="path",
+     *     description="Id of Expense",
+     *     @OA\Schema(type="int")
+     * )
+     * @OA\Tag(name="expenses")
+     *
+     * @param int $id
+     *
+     * @return Response
+     */
+    #[Route('/expenses/{id}', name: 'get_expense_by_id', methods: ['GET'])]
+    public function getExpenseById(int $id): Response
+    {
+        return new JsonResponse([], 200, ['Content-Type' => 'application/json']);
+    }
 }

--- a/src/Controller/ExpensesController.php
+++ b/src/Controller/ExpensesController.php
@@ -15,6 +15,7 @@ use Nelmio\ApiDocBundle\Annotation\Model;
 use OpenApi\Annotations as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\CssSelector\Exception\InternalErrorException;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -166,8 +167,12 @@ class ExpensesController extends AbstractController
      * @return Response
      */
     #[Route('/expenses/{id}', name: 'get_expense_by_id', methods: ['GET'])]
-    public function getExpenseById(int $id): Response
+    public function getExpenseById(string $id): Response
     {
+        if (!is_numeric($id)) {
+            throw new BadRequestException('Expense Id must be of type int');
+        }
+
         $expense = $this->repository->find($id);
         if (!$expense) {
             throw new NotFoundException('Expense', $id);

--- a/src/Controller/ExpensesController.php
+++ b/src/Controller/ExpensesController.php
@@ -157,7 +157,7 @@ class ExpensesController extends AbstractController
      *     name="id",
      *     in="path",
      *     description="Id of Expense",
-     *     @OA\Schema(type="int")
+     *     @OA\Schema(type="integer")
      * )
      * @OA\Tag(name="expenses")
      *
@@ -168,6 +168,11 @@ class ExpensesController extends AbstractController
     #[Route('/expenses/{id}', name: 'get_expense_by_id', methods: ['GET'])]
     public function getExpenseById(int $id): Response
     {
-        return new JsonResponse([], 200, ['Content-Type' => 'application/json']);
+        $expense = $this->repository->find($id);
+        if (!$expense) {
+            throw new NotFoundException('Expense', $id);
+        }
+
+        return new JsonResponse(ExpenseMapper::entityToResponseDto($expense), 200, ['Content-Type' => 'application/json']);
     }
 }

--- a/src/Controller/ExpensesController.php
+++ b/src/Controller/ExpensesController.php
@@ -40,7 +40,7 @@ class ExpensesController extends AbstractController
      *        @OA\Items(ref=@Model(type=ExpenseResponseDto::class))
      *     )
      * )
-     * @OA\Tag(name="expenses")
+     * @OA\Tag(name="Expenses")
      *
      * @return Response
      */
@@ -97,7 +97,7 @@ class ExpensesController extends AbstractController
      *          )
      *      )
      * )
-     * @OA\Tag(name="expenses")
+     * @OA\Tag(name="Expenses")
      *
      * @param CreateExpenseRequestDto $createExpenseDto
      *
@@ -160,9 +160,9 @@ class ExpensesController extends AbstractController
      *     description="Id of Expense",
      *     @OA\Schema(type="integer")
      * )
-     * @OA\Tag(name="expenses")
+     * @OA\Tag(name="Expenses")
      *
-     * @param int $id
+     * @param string $id
      *
      * @return Response
      */

--- a/src/Controller/ExpensesController.php
+++ b/src/Controller/ExpensesController.php
@@ -66,6 +66,12 @@ class ExpensesController extends AbstractController
      *     response=400,
      *     description="Bad Request"
      * )
+     *
+     * @OA\Response(
+     *     response=404,
+     *     description="Expense type not found"
+     * )
+     *
      * @OA\RequestBody(
      *      description="Expense details",
      *      @OA\MediaType(

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -5,9 +5,10 @@ namespace App\DataFixtures;
 use App\Entity\ExpenseType;
 use App\Enums\ExpenseTypeEnum;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class AppFixtures extends Fixture
+class AppFixtures extends Fixture implements FixtureGroupInterface
 {
     public function load(ObjectManager $manager): void
     {
@@ -37,5 +38,10 @@ class AppFixtures extends Fixture
         $expenseType->setName($name);
 
         return $expenseType;
+    }
+
+    public static function getGroups(): array
+    {
+        return ['app-initial-data'];
     }
 }

--- a/src/DataFixtures/TestFixtures.php
+++ b/src/DataFixtures/TestFixtures.php
@@ -10,20 +10,28 @@ use Doctrine\Persistence\ObjectManager;
 
 class TestFixtures extends Fixture
 {
-    public function load(ObjectManager $manager, string $description = 'Test Expense'): void
-    {
-        self::seedExpenses($manager, $description);
+    public function load(
+        ObjectManager $manager,
+        string $description = 'Test Expense',
+        int $value = 12,
+        string $type = ExpenseTypeEnum::ENTERTAINMENT
+    ): void {
+        self::seedExpenses($manager, $description, $value, $type);
     }
 
-    private static function seedExpenses(ObjectManager $manager, string $description)
-    {
+    private static function seedExpenses(
+        ObjectManager $manager,
+        string $description,
+        int $value,
+        string $typeName
+    ) {
         $expense = new Expense();
         $expense->setDescription($description);
-        $expense->setValue(12);
+        $expense->setValue($value);
 
         $expenseTypeRepo = $manager->getRepository(ExpenseType::class);
         $type = $expenseTypeRepo->findOneBy([
-            'name' => ExpenseTypeEnum::ENTERTAINMENT,
+            'name' => $typeName,
         ]);
         $expense->setExpenseType($type);
 

--- a/src/Dto/ExpenseResponseDto.php
+++ b/src/Dto/ExpenseResponseDto.php
@@ -32,5 +32,9 @@ class ExpenseResponseDto
         float $value,
         string $type
     ) {
+        $this->id = $id;
+        $this->description = $description;
+        $this->value = $value;
+        $this->type = $type;
     }
 }

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -2,7 +2,9 @@
 
 namespace App\Exceptions;
 
-class NotFoundException extends \RuntimeException
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class NotFoundException extends NotFoundHttpException
 {
     public function __construct(string $entityName, int|string $id)
     {

--- a/src/Listeners/ExceptionListener.php
+++ b/src/Listeners/ExceptionListener.php
@@ -2,7 +2,6 @@
 
 namespace App\Listeners;
 
-use App\Exceptions\NotFoundException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -26,9 +25,7 @@ class ExceptionListener implements LoggerAwareInterface
 
         $this->logger->error($exception->getMessage(), $exception->getTrace());
 
-        if ($exception instanceof NotFoundException) {
-            $response->setStatusCode(Response::HTTP_NOT_FOUND);
-        } elseif ($exception instanceof HttpExceptionInterface) {
+        if ($exception instanceof HttpExceptionInterface) {
             $response->setStatusCode($exception->getStatusCode());
             $response->headers->replace($exception->getHeaders());
         } else {


### PR DESCRIPTION
## Changes ✏️

- Added `GET /expenses/{id}` endpoint

## To Test 🧪

- run `composer test` and expect 100% success rate.
- hit the endpoint manually

```curl
curl --location --request GET 'http://localhost:8000/api/expenses/1'
```

## PR Checklist ✅

- [x] I've tested the code end-to-end manually
- [x] I've added any new endpoints to Postman;
- [x] I've added Swagger.
- [ ] I've added unit test.
- [x] I've added integration test.
